### PR TITLE
On small devices, scroll bar for the image of aqua members starts at the center rather than at the left

### DIFF
--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -26,8 +26,8 @@ export default function Page() {
       >
         <img
           src="/images/members/aqua-group-221117.jpg"
-          alt="Group"
-          className="object-center min-w-[1000px] min-h-[361px]"
+          alt="Picture of AQUA Members"
+          className="min-w-[1000px] min-h-[361px]"
         />
       </div>
       <div className="flex flex-col items-center justify-center mx-10 py-10">

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -7,20 +7,23 @@ import { cn } from "@/components/utils"
 
 export default function Page() {
   const [searchQuery, setSearchQuery] = useState("")
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     const container = containerRef.current
-    if(container){
-      const scrollAmount = (container.scrollWidth - container.clientWidth)/2
-      container.scrollLeft = scrollAmount;
+    if (container) {
+      const scrollAmount = (container.scrollWidth - container.clientWidth) / 2
+      container.scrollLeft = scrollAmount
     }
   }, [])
 
   return (
     <div className="flex flex-col items-center justify-center w-full">
       {/* top section with image */}
-      <div ref={containerRef} className="overscroll-auto overflow-x-scroll w-full h-[50vh] l:h-[55vh] xl:h-[60vh] bg-gradient-to-b to-primary/25 from-primary-100">
+      <div
+        ref={containerRef}
+        className="overscroll-auto overflow-x-scroll w-full h-[50vh] l:h-[55vh] xl:h-[60vh] bg-gradient-to-b to-primary/25 from-primary-100"
+      >
         <img
           src="/images/members/aqua-group-221117.jpg"
           alt="Group"

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,21 +1,30 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import { members } from "./members-data"
 import MemberCard from "./member-card"
 import { cn } from "@/components/utils"
 
 export default function Page() {
   const [searchQuery, setSearchQuery] = useState("")
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current
+    if(container){
+      const scrollAmount = (container.scrollWidth - container.clientWidth)/2
+      container.scrollLeft = scrollAmount;
+    }
+  }, [])
 
   return (
     <div className="flex flex-col items-center justify-center w-full">
       {/* top section with image */}
-      <div className="overscroll-auto overflow-x-scroll w-full h-[50vh] l:h-[55vh] xl:h-[60vh] bg-gradient-to-b to-primary/25 from-primary-100">
+      <div ref={containerRef} className="overscroll-auto overflow-x-scroll w-full h-[50vh] l:h-[55vh] xl:h-[60vh] bg-gradient-to-b to-primary/25 from-primary-100">
         <img
           src="/images/members/aqua-group-221117.jpg"
           alt="Group"
-          className="min-w-[1000px] min-h-[361px]"
+          className="object-center min-w-[1000px] min-h-[361px]"
         />
       </div>
       <div className="flex flex-col items-center justify-center mx-10 py-10">


### PR DESCRIPTION
As per rdv's request on Slack. Doesn't work when users resize windows though -- would have to put that into the useEffect hook if you wanted. 