### PR TITLE
Closes 148. No more img stretching. Simply crops instead

### DIFF
--- a/src/app/members/member-card.tsx
+++ b/src/app/members/member-card.tsx
@@ -9,7 +9,7 @@ const MemberCard = ({ member }: { member: TMember }) => (
     )}
   >
     <img
-      className="w-32 h-32 rounded-full"
+      className="w-32 h-32 rounded-full object-cover"
       src={member.imagePath}
       alt={member.name}
     />


### PR DESCRIPTION
Simply adding object-cover to the className for the img works for most people, but it crops out e.g. Sara's face completely. Might be best to make people have photos with reasonable aspect ratios otherwise youd have to run like a face-detecting algorithm to detect where the face is and then crop automatically, which, although interesting, sounds like more work than it's worth.