### PR TITLE
Add redirect to QCE 2025 keynote.

### DIFF
--- a/src/app/redirect/qce-2025-keynote/page.tsx
+++ b/src/app/redirect/qce-2025-keynote/page.tsx
@@ -1,0 +1,5 @@
+import { permanentRedirect } from 'next/navigation'
+
+export default function Page() {
+  permanentRedirect('https://docs.google.com/presentation/d/16pDsMia2eJae-dG3Q93Zpkuf_ONhpcEox1KCjbNzpzA/edit?usp=sharing')
+}


### PR DESCRIPTION
Add a new, invisible directory called `redirect`, below which we can make subdirectories that redirect to outside links, such as Rod-sensei's QCE keynote.